### PR TITLE
Added to if statement because of bug in yumrepos

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -77,6 +77,8 @@ define yum::repo (
   	if ! $gpgkey and $gpgkey == undef {
   		fail("specify a valid url for gpgkey")
   	}
+  } else {
+    $gpgcheck = 0
   }
 
   yumrepo { $name:

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -72,13 +72,11 @@ define yum::repo (
 ){
   include yum
 
-  if $gpgcheck {
+  if $gpgcheck and ! $gpgkey == 0 {
   	validate_string($gpgkey)
   	if ! $gpgkey and $gpgkey == undef {
   		fail("specify a valid url for gpgkey")
   	}
-  } else {
-    $gpgcheck = 0
   }
 
   yumrepo { $name:


### PR DESCRIPTION
yumrepos defined type does NOT add the gpgcheck=false line if you have false or nothing for gpgcheck.  it HAS to be zero.  i've opened a support request with puppet labs, but this addition to the if statement allows me to use 0 instead of false in my profiles,without being told i need a url for gpgcheck
